### PR TITLE
Feat/edit title

### DIFF
--- a/app/db/database_connection.py
+++ b/app/db/database_connection.py
@@ -111,6 +111,24 @@ def get_app_title():
         if conn:
             conn.close()
 
+def update_app_title(new_title):
+    conn = connect_to_db()
+    if conn is None:
+        logging.error("Failed to connect to the database.")
+        return
+
+    try:
+        with conn.cursor() as cur:
+            cur.execute("""
+                UPDATE app_title SET description = %s WHERE id = 1;
+            """, (new_title,))
+            conn.commit()
+            logging.info("App description updated successfully.")
+    except Exception as e:
+        logging.error(f"Error updating app title: {e}")
+    finally:
+        if conn:
+            conn.close()
 
 
 def update_app_description(new_description):

--- a/app/db/database_connection.py
+++ b/app/db/database_connection.py
@@ -89,6 +89,29 @@ def get_app_description():
         if conn:
             conn.close()
 
+def get_app_title():
+    conn = connect_to_db()
+    if conn is None:
+        logging.error("Failed to connect to the database.")
+        return "Default app title here."
+
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT title FROM app_title WHERE id = 1;")
+            description = cur.fetchone()
+            if description:
+                return description[0]
+            else:
+                return "CherGPT"
+
+    except Exception as e:
+        logging.error(f"Error fetching app title: {e}")
+        return "CherGPT."
+    finally:
+        if conn:
+            conn.close()
+
+
 
 def update_app_description(new_description):
     conn = connect_to_db()

--- a/app/db/database_connection.py
+++ b/app/db/database_connection.py
@@ -60,6 +60,22 @@ def initialize_db():
                 ON CONFLICT (id) DO NOTHING;
             """)
 
+            # Initialize app_title table
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS app_title (
+                    id SERIAL PRIMARY KEY,
+                    description TEXT
+                );
+            """)
+            
+            # Ensure there is always one row in app_title to update
+            cur.execute("""
+                INSERT INTO app_title (id, description)
+                VALUES (1, 'CherGPT')
+                ON CONFLICT (id) DO NOTHING;
+            """)
+
+
         conn.commit()
     except Exception as e:
         logging.error(f"Error initializing database: {e}")
@@ -97,7 +113,7 @@ def get_app_title():
 
     try:
         with conn.cursor() as cur:
-            cur.execute("SELECT title FROM app_title WHERE id = 1;")
+            cur.execute("SELECT description FROM app_title WHERE id = 1;")
             description = cur.fetchone()
             if description:
                 return description[0]
@@ -106,7 +122,7 @@ def get_app_title():
 
     except Exception as e:
         logging.error(f"Error fetching app title: {e}")
-        return "CherGPT."
+        return "CherGPT"
     finally:
         if conn:
             conn.close()

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from app.db.database_connection import get_app_description, get_app_title, initi
 from app.instructions.instructions_handler import get_latest_instructions
 import uuid
 
-app_title = get_app_title() or "CherGPT"
+app_title = get_app_title()
 app_description = get_app_description() or "Chatbot to support teaching and learning"
 st.title(app_title)
 # Initialize session state for admin

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from app.instructions.instructions_handler import get_latest_instructions
 import uuid
 
 st.title("CherGPT Basic")
+app_title = get_app_title() or "CherGPT"
 app_description = get_app_description() or "Chatbot to support teaching and learning"
 # Initialize session state for admin
 if "is_admin" not in st.session_state:

--- a/main.py
+++ b/main.py
@@ -7,13 +7,13 @@ import logging
 import streamlit as st
 from app.chatlog.chatlog_handler import insert_chat_log, initialize_chatlog_table
 from sidebar import setup_sidebar
-from app.db.database_connection import connect_to_db, get_app_description, initialize_db, update_app_description
+from app.db.database_connection import get_app_description, get_app_title, initialize_db, update_app_description
 from app.instructions.instructions_handler import get_latest_instructions
 import uuid
 
-st.title("CherGPT Basic")
 app_title = get_app_title() or "CherGPT"
 app_description = get_app_description() or "Chatbot to support teaching and learning"
+st.title(app_title)
 # Initialize session state for admin
 if "is_admin" not in st.session_state:
     st.session_state["is_admin"] = False

--- a/sidebar.py
+++ b/sidebar.py
@@ -26,12 +26,19 @@ def setup_sidebar():
 
     if st.session_state.get("is_admin", False):
         with st.sidebar:
+            with st.expander("⚙️ Edit Title"):
+                editable_title = st.text_area("This amends title", value=app_title, key="app_title")
+                # Button to save the updated app description
+                if st.button("Update title", key="save_app_title"):
+                    # Update the app description in the database
+                    update_app_title(editable_title)
+                    st.success("App description updated successfully")
             # Check if the user is an admin to provide editing capability
             # Provide a text area for admins to edit the app description
             with st.expander("⚙️ Edit description"):
                 editable_description = st.text_area("This amends text below title", value=app_description, key="app_description")
                 # Button to save the updated app description
-                if st.button("Update description", key="save_app_description"):
+                if st.button("Update description", key="save_app_title"):
                     # Update the app description in the database
                     update_app_description(editable_description)
                     st.success("App description updated successfully")

--- a/sidebar.py
+++ b/sidebar.py
@@ -1,14 +1,15 @@
 import streamlit as st
 from app.chatlog.chatlog_handler import compile_summaries, delete_all_chatlogs, export_chat_logs_to_csv, drop_chatlog_table, fetch_and_batch_chatlogs, generate_summary_for_each_group
 from app.instructions.instructions_handler import get_latest_instructions, update_instructions
-from app.db.database_connection import  drop_instructions_table, get_app_description, update_app_description
+from app.db.database_connection import  drop_instructions_table, get_app_description, update_app_description, get_app_title, update_app_title
 custominstructions_area_height = 300
+app_title = get_app_title()
 app_description = get_app_description()
 
 def load_summaries():
     # Placeholder function call - replace with actual function logic
     batches = fetch_and_batch_chatlogs()
-    group_summaries = generate_summary_for_each_group(batches)
+    group_summaries = generate_summary_for_each_group(batches) 
     final_summary_output = compile_summaries(group_summaries)
     return final_summary_output
 
@@ -32,13 +33,13 @@ def setup_sidebar():
                 if st.button("Update title", key="save_app_title"):
                     # Update the app description in the database
                     update_app_title(editable_title)
-                    st.success("App description updated successfully")
+                    st.success("App title updated successfully")
             # Check if the user is an admin to provide editing capability
             # Provide a text area for admins to edit the app description
             with st.expander("⚙️ Edit description"):
                 editable_description = st.text_area("This amends text below title", value=app_description, key="app_description")
                 # Button to save the updated app description
-                if st.button("Update description", key="save_app_title"):
+                if st.button("Update description", key="save_app_description"):
                     # Update the app description in the database
                     update_app_description(editable_description)
                     st.success("App description updated successfully")


### PR DESCRIPTION
admin users can now edit titles of their application via UI instead of making code changes as needed
BEFORE
Title defaults to "CherGPT"

AFTER
<img width="854" alt="image" src="https://github.com/user-attachments/assets/73b0a530-9c18-4405-916a-bc7dcaaf8bf7">

Checks
[x] tested locally - update, defaults
[x] database defaults to values if empty (CherGPT)